### PR TITLE
Add `calls/caller/{phoneNumber}` to docs

### DIFF
--- a/openapi/exportEndpoints/exportCallsCaller.yaml
+++ b/openapi/exportEndpoints/exportCallsCaller.yaml
@@ -1,0 +1,98 @@
+openapi: 3.0.0
+info:
+  title: Calls API
+  version: 1.0.0
+paths:
+  /calls/caller/{phoneNumber}:
+    get:
+      tags:
+        - Calls
+      summary: Get calls by phone number
+      description: Fetch call records associated with a specific phone number.
+      operationId: getCallByPhoneNumber
+      parameters:
+        - name: phoneNumber
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The phone number to fetch call records for
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CarrierSale'
+        "400":
+          $ref: '#/components/responses/ErrorResponse'
+        "401":
+          $ref: '#/components/responses/ErrorResponse'
+        "403":
+          $ref: '#/components/responses/ErrorResponse'
+
+components:
+  schemas:
+    Bid:
+      type: object
+      properties:
+        loadId:
+          type: string
+          description: The load ID associated with the bid
+        id:
+          type: integer
+          description: The ID of the bid
+        bidAmount:
+          type: string
+          description: The amount of the bid
+        initialBid:
+          type: string
+          nullable: true
+          description: The initial bid amount, if any
+    CarrierSale:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: The ID of the carrier sale
+        type:
+          type: string
+          enum:
+            - CARRIER_SALE
+            - CARRIER_SALE_INBOUND
+            - OTHER
+            - UNKNOWN
+            - OUTBOUND
+          description: The type of the carrier sale
+        status:
+          type: string
+          enum:
+            - COMPLETED
+            - IN_PROGRESS
+            - ANSWERED
+          description: The status of the carrier sale
+        time:
+          type: string
+          format: date-time
+          description: The date and time of the carrier sale
+        summary:
+          type: string
+          nullable: true
+          description: An optional summary of the carrier sale
+        bids:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bid'
+
+  responses:
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: The error code
+        message:
+          type: string
+          description: A message describing the error

--- a/openapi/fleetworks.yaml
+++ b/openapi/fleetworks.yaml
@@ -32,6 +32,8 @@ paths:
     $ref: "inboundWebhooks/carrierEventApi.yaml#/paths/~1"
   "/api/v1/calls":
     $ref: "exportEndpoints/exportCalls.yaml#/paths/~1"
+  "/api/v1/calls/caller/{phoneNumber}":
+    $ref: "exportEndpoints/exportCallsCaller.yaml#/paths/~1"
   "/api/v1/bids":
     $ref: "exportEndpoints/exportBids.yaml#/paths/~1"
   "/api/v1/carriers":

--- a/openapi/fleetworks_openapi.json
+++ b/openapi/fleetworks_openapi.json
@@ -1533,7 +1533,10 @@
             "items" : {
               "$ref" : "#/components/schemas/CallForExport"
             },
-            "type" : "object"
+            "type" : "array"
+          },
+          "pagination" : {
+            "$ref" : "#/components/schemas/PaginationResponse"
           }
         },
         "type" : "object"

--- a/openapi/fleetworks_openapi.json
+++ b/openapi/fleetworks_openapi.json
@@ -232,6 +232,72 @@
         "tags" : [ "Calls" ]
       }
     },
+    "/api/v1/calls/caller/{phoneNumber}": {
+      "get": {
+        "description": "List latest call record for a specified phone number.",
+        "operationId": "getCallByPhoneNumber",
+        "parameters": [
+          {
+            "description": "Caller phone number in E.164 format. For example: +18008463400 or +15152733178",
+            "in": "path",
+            "name": "phoneNumber",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getCallByPhoneNumber_200_response"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/webhooksLoadsEvents_400_response"
+                }
+              }
+            },
+            "description": "Error response, or incorrect phone number format"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/webhooksLoadsEvents_400_response"
+                }
+              }
+            },
+            "description": "Error response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/webhooksLoadsEvents_400_response"
+                }
+              }
+            },
+            "description": "Error response"
+          }
+        },
+        "security": [
+          {
+            "auth": []
+          }
+        ],
+        "summary": "Fetch call by number",
+        "tags": ["Calls"]
+      }
+    },
     "/api/v1/bids" : {
       "get" : {
         "description" : "List bid records for an organization within a specified time range. Optional filtering by load ID and MC number is supported.",
@@ -884,6 +950,66 @@
         "required" : [ "dayRangeSpread", "laneAverageRate", "marketAverageRate", "ratePerMileTrend", "volumeTrend" ],
         "type" : "object"
       },
+      "LatestCallerInfo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The ID of the carrier sale"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "CARRIER_SALE",
+              "CARRIER_SALE_INBOUND",
+              "OTHER",
+              "UNKNOWN",
+              "OUTBOUND"
+            ],
+            "description": "The type of the carrier sale"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["COMPLETED", "IN_PROGRESS", "ANSWERED"],
+            "description": "The status of the carrier sale"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time of the carrier sale"
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true,
+            "description": "An optional summary of the carrier sale"
+          },
+          "bids": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "loadId": {
+                  "type": "string",
+                  "description": "The load ID associated with the bid"
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "The ID of the bid"
+                },
+                "bidAmount": {
+                  "type": "string",
+                  "description": "The amount of the bid"
+                },
+                "initialBid": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "The initial bid amount, if any"
+                }
+              }
+            }
+          }
+        }
+      },
       "CallForExport" : {
         "properties" : {
           "id" : {
@@ -1407,13 +1533,17 @@
             "items" : {
               "$ref" : "#/components/schemas/CallForExport"
             },
-            "type" : "array"
-          },
-          "pagination" : {
-            "$ref" : "#/components/schemas/PaginationResponse"
+            "type" : "object"
           }
         },
         "type" : "object"
+      },
+      "getCallByPhoneNumber_200_response" : {
+        "allOf": [
+          {
+            "$ref" : "#/components/schemas/LatestCallerInfo"
+          }
+        ]
       },
       "listBids_200_response" : {
         "properties" : {


### PR DESCRIPTION
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/95f03291-d573-480f-b9c7-58ca87ad9801">
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/6aff0c56-3931-4850-be01-68a719f3b493">
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/4a128656-ddd7-4988-bbd8-e297f38ccdd3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint to retrieve call records by phone number: `GET /calls/caller/{phoneNumber}`.
	- Added response schemas for successful and error responses, enhancing data consistency.
	- New schema `LatestCallerInfo` provides detailed information about the latest call associated with a phone number.

- **Documentation**
	- Updated OpenAPI specifications to reflect the new endpoint and associated schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->